### PR TITLE
Fix docker api

### DIFF
--- a/build_versions.py
+++ b/build_versions.py
@@ -262,8 +262,6 @@ def build_new_or_updated(current_versions, versions, dry_run=False, debug=False)
                 print(f"Failed building {version}, skipping...")
                 failed_builds.append(version)
     return failed_builds
-                        
-
 
 
 def update_readme_tags_table(versions, dry_run=False):
@@ -274,9 +272,9 @@ def update_readme_tags_table(versions, dry_run=False):
     headings = ["Tag", "pgAdmin version", "Python version", "Distro"]
     rows = []
     for v in versions:
-        rows.append([f"`{v['key']}`", v["pgadmin"], v["python_canonical"], v["distro"]])
+        rows.append([f"| `{v['key']}`", v["pgadmin"], v["python_canonical"], f"{v['distro']} |"])
 
-    head = f"{' | '.join(headings)}\n{' | '.join(['---' for h in headings])}"
+    head = f"| {' | '.join(headings)} |\n| {' | '.join(['---' for h in headings])} |"
     body = "\n".join([" | ".join(row) for row in rows])
     table = f"{head}\n{body}\n"
 

--- a/build_versions.py
+++ b/build_versions.py
@@ -45,8 +45,20 @@ def scrape_supported_python_versions():
 
     r = HTMLSession().get("https://devguide.python.org/versions/")
     version_table = r.html.find(version_table_selector, first=True)
+
+    # match development information with latest downloadable release
+    _py_specific_release = ".download-list-widget li"
+    r = HTMLSession().get("https://www.python.org/downloads/")
+    spec_table = r.html.find(_py_specific_release)
+    _downloadable_versions = [li.find('span a', first=True).text.split(' ')[1] for li in spec_table]
+
     for ver in version_table.find("tbody tr"):
         branch, _, _, first_release, end_of_life, _ = [v.text for v in ver.find("td")]
+
+        _matching_version = list(filter(lambda d: d.startswith(branch), _downloadable_versions))
+        if _matching_version:
+            branch = _matching_version[0]
+
         versions.append({"version": branch, "start": first_release, "end": end_of_life})
 
     return versions


### PR DESCRIPTION
- match python active branches with latest downloadable release
- use docker v2 api, adding "name" filter using python version, to avoid looping on all tag pages and filter python development releases